### PR TITLE
Add starter Streamlit budget forecasting app, engine, and Excel export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# ACPL Budget Forecasting Automation
+
+This repository contains a starter app for automating budget forecasting from an existing Excel workbook.
+
+## What it does
+
+- Reads an `Expenses` tab from your Excel file.
+- Lets you edit company-level forecasts in a simple Streamlit app.
+- Builds:
+  - Company-level budget vs expense summary
+  - Consolidated summary across all companies
+  - Cash flow projection by scenario
+  - Scenario-specific report tabs
+- Exports a refreshed Excel workbook for sharing.
+
+## Expected `Expenses` columns
+
+The app expects these columns in the `Expenses` sheet:
+
+- `company`
+- `person`
+- `item`
+- `scenario`
+- `month`
+- `budget`
+- `expense`
+
+## Run locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run acpl_app.py
+```
+
+## Tests
+
+```bash
+pytest
+```

--- a/acpl_app.py
+++ b/acpl_app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import pandas as pd
+import streamlit as st
+
+from src.budget_engine import (
+    BudgetWorkbook,
+    default_template,
+    export_dashboard_workbook,
+)
+
+st.set_page_config(page_title="ACPL Budget Automation", layout="wide")
+st.title("ACPL Budget Forecasting Automation")
+st.caption("Upload your workbook, edit forecasts by company, and export scenario dashboards.")
+
+with st.sidebar:
+    st.header("Workbook Input")
+    uploaded_file = st.file_uploader("Upload budget workbook", type=["xlsx"])
+    opening_cash = st.number_input("Opening cash balance", value=0.0, step=1000.0)
+    st.markdown("If you don't have a workbook ready, use a template starter file.")
+
+    if st.button("Download template workbook"):
+        template_bytes = default_template()
+        st.download_button(
+            label="Save template",
+            data=template_bytes,
+            file_name="acpl_budget_template.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+if not uploaded_file:
+    st.info("Upload an Excel workbook to begin. Expected sheet: `Expenses`.")
+    st.stop()
+
+workbook = BudgetWorkbook.from_excel(uploaded_file)
+
+st.subheader("Editable Forecast Grid")
+companies = sorted(workbook.expenses["company"].dropna().unique().tolist())
+selected_company = st.selectbox("Company", companies)
+company_df = workbook.expenses[workbook.expenses["company"] == selected_company].copy()
+
+edited_company_df = st.data_editor(
+    company_df,
+    hide_index=True,
+    num_rows="dynamic",
+    use_container_width=True,
+    column_config={
+        "month": st.column_config.DateColumn("Month"),
+        "budget": st.column_config.NumberColumn("Budget", format="$%.2f"),
+        "expense": st.column_config.NumberColumn("Expense", format="$%.2f"),
+    },
+)
+
+if st.button("Apply edits for selected company"):
+    workbook.apply_company_updates(selected_company, edited_company_df)
+    st.success("Forecast updated in memory.")
+
+scenario_options = sorted(workbook.expenses["scenario"].dropna().unique().tolist())
+selected_scenarios = st.multiselect(
+    "Scenarios to include in dashboard/report",
+    options=scenario_options,
+    default=scenario_options[:2] if len(scenario_options) >= 2 else scenario_options,
+)
+
+if not selected_scenarios:
+    st.warning("Select at least one scenario.")
+    st.stop()
+
+company_summary = workbook.company_summary(scenarios=selected_scenarios)
+consolidated = workbook.consolidated_summary(scenarios=selected_scenarios)
+cash_flow = workbook.cash_flow(scenarios=selected_scenarios, opening_cash=opening_cash)
+scenario_reports = workbook.scenario_reports(scenarios=selected_scenarios, opening_cash=opening_cash)
+
+col1, col2 = st.columns(2)
+with col1:
+    st.subheader("Company Summary")
+    st.dataframe(company_summary, use_container_width=True)
+with col2:
+    st.subheader("Consolidated Summary")
+    st.dataframe(consolidated, use_container_width=True)
+
+st.subheader("Cash Flow Projection")
+st.line_chart(
+    cash_flow,
+    x="month",
+    y="closing_cash",
+    color="scenario",
+    use_container_width=True,
+)
+st.dataframe(cash_flow, use_container_width=True)
+
+st.subheader("Scenario Reports")
+for scenario_name, report_df in scenario_reports.items():
+    st.markdown(f"#### {scenario_name}")
+    st.dataframe(report_df, use_container_width=True)
+
+export_buffer = BytesIO()
+export_dashboard_workbook(
+    export_buffer,
+    workbook.expenses,
+    opening_cash=opening_cash,
+    scenarios=selected_scenarios,
+)
+
+st.download_button(
+    label="Export dashboard workbook",
+    data=export_buffer.getvalue(),
+    file_name="acpl_budget_dashboard.xlsx",
+    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.42
+pandas>=2.2
+openpyxl>=3.1
+xlsxwriter>=3.2
+pytest>=8.3

--- a/src/budget_engine.py
+++ b/src/budget_engine.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from typing import BinaryIO
+
+import pandas as pd
+
+REQUIRED_COLUMNS = {
+    "company",
+    "person",
+    "item",
+    "scenario",
+    "month",
+    "budget",
+    "expense",
+}
+
+
+@dataclass
+class BudgetWorkbook:
+    expenses: pd.DataFrame
+
+    @classmethod
+    def from_excel(cls, file: BinaryIO | BytesIO) -> "BudgetWorkbook":
+        raw = pd.read_excel(file, sheet_name="Expenses")
+        normalized = _normalize_expenses(raw)
+        return cls(expenses=normalized)
+
+    def apply_company_updates(self, company: str, edited_company_df: pd.DataFrame) -> None:
+        remainder = self.expenses[self.expenses["company"] != company].copy()
+        updated_company = _normalize_expenses(edited_company_df)
+        self.expenses = pd.concat([remainder, updated_company], ignore_index=True)
+
+    def company_summary(self, scenarios: list[str]) -> pd.DataFrame:
+        scoped = self.expenses[self.expenses["scenario"].isin(scenarios)].copy()
+        grouped = (
+            scoped.groupby(["company", "scenario", "month"], as_index=False)
+            .agg(budget=("budget", "sum"), expense=("expense", "sum"))
+            .sort_values(["company", "scenario", "month"])
+        )
+        grouped["variance"] = grouped["budget"] - grouped["expense"]
+        return grouped
+
+    def consolidated_summary(self, scenarios: list[str]) -> pd.DataFrame:
+        scoped = self.expenses[self.expenses["scenario"].isin(scenarios)].copy()
+        grouped = (
+            scoped.groupby(["scenario", "month"], as_index=False)
+            .agg(budget=("budget", "sum"), expense=("expense", "sum"))
+            .sort_values(["scenario", "month"])
+        )
+        grouped["net_flow"] = grouped["budget"] - grouped["expense"]
+        return grouped
+
+    def cash_flow(self, scenarios: list[str], opening_cash: float = 0.0) -> pd.DataFrame:
+        consolidated = self.consolidated_summary(scenarios)
+
+        def add_running_balance(frame: pd.DataFrame) -> pd.DataFrame:
+            frame = frame.sort_values("month").copy()
+            frame["closing_cash"] = opening_cash + frame["net_flow"].cumsum()
+            return frame
+
+        return consolidated.groupby("scenario", group_keys=False).apply(add_running_balance).reset_index(drop=True)
+
+    def scenario_reports(self, scenarios: list[str], opening_cash: float = 0.0) -> dict[str, pd.DataFrame]:
+        cash = self.cash_flow(scenarios, opening_cash)
+        reports: dict[str, pd.DataFrame] = {}
+        for scenario in scenarios:
+            scenario_cash = cash[cash["scenario"] == scenario]
+            reports[scenario] = scenario_cash[["month", "budget", "expense", "net_flow", "closing_cash"]].copy()
+        return reports
+
+
+def _normalize_expenses(raw: pd.DataFrame) -> pd.DataFrame:
+    df = raw.copy()
+    df.columns = [str(c).strip().lower() for c in df.columns]
+
+    missing = REQUIRED_COLUMNS.difference(df.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"Expenses sheet is missing required columns: {missing_str}")
+
+    df = df[list(REQUIRED_COLUMNS)].copy()
+    df["month"] = pd.to_datetime(df["month"]).dt.to_period("M").dt.to_timestamp()
+    df["budget"] = pd.to_numeric(df["budget"], errors="coerce").fillna(0.0)
+    df["expense"] = pd.to_numeric(df["expense"], errors="coerce").fillna(0.0)
+
+    for text_col in ["company", "person", "item", "scenario"]:
+        df[text_col] = df[text_col].astype(str).str.strip()
+
+    return df.sort_values(["company", "scenario", "month", "item", "person"]).reset_index(drop=True)
+
+
+def export_dashboard_workbook(
+    file_obj: BinaryIO | BytesIO,
+    expenses_df: pd.DataFrame,
+    opening_cash: float,
+    scenarios: list[str],
+) -> None:
+    workbook = BudgetWorkbook(expenses=expenses_df)
+    company_summary = workbook.company_summary(scenarios)
+    consolidated = workbook.consolidated_summary(scenarios)
+    cash_flow = workbook.cash_flow(scenarios, opening_cash)
+    reports = workbook.scenario_reports(scenarios, opening_cash)
+
+    with pd.ExcelWriter(file_obj, engine="xlsxwriter") as writer:
+        workbook.expenses.to_excel(writer, sheet_name="Expenses", index=False)
+        company_summary.to_excel(writer, sheet_name="Company Summary", index=False)
+        consolidated.to_excel(writer, sheet_name="Consolidated", index=False)
+        cash_flow.to_excel(writer, sheet_name="Cash Flow", index=False)
+
+        for scenario, frame in reports.items():
+            safe_name = str(scenario)[:27]
+            frame.to_excel(writer, sheet_name=f"Report {safe_name}", index=False)
+
+
+def default_template() -> bytes:
+    template = pd.DataFrame(
+        [
+            {
+                "company": "Company A",
+                "person": "Jane Doe",
+                "item": "Marketing",
+                "scenario": "Base",
+                "month": "2026-01-01",
+                "budget": 20000,
+                "expense": 18000,
+            },
+            {
+                "company": "Company A",
+                "person": "Jane Doe",
+                "item": "Marketing",
+                "scenario": "Conservative",
+                "month": "2026-01-01",
+                "budget": 18000,
+                "expense": 17000,
+            },
+        ]
+    )
+    output = BytesIO()
+    with pd.ExcelWriter(output, engine="xlsxwriter") as writer:
+        template.to_excel(writer, sheet_name="Expenses", index=False)
+    return output.getvalue()

--- a/tests/test_budget_engine.py
+++ b/tests/test_budget_engine.py
@@ -1,0 +1,33 @@
+from io import BytesIO
+
+import pandas as pd
+
+from src.budget_engine import BudgetWorkbook, default_template, export_dashboard_workbook
+
+
+def test_template_loads_and_builds_summaries() -> None:
+    template_bytes = default_template()
+    workbook = BudgetWorkbook.from_excel(BytesIO(template_bytes))
+
+    company_summary = workbook.company_summary(["Base", "Conservative"])
+    consolidated = workbook.consolidated_summary(["Base", "Conservative"])
+    cash_flow = workbook.cash_flow(["Base", "Conservative"], opening_cash=1000)
+
+    assert not company_summary.empty
+    assert not consolidated.empty
+    assert "closing_cash" in cash_flow.columns
+
+
+def test_export_creates_expected_tabs() -> None:
+    template_bytes = default_template()
+    workbook = BudgetWorkbook.from_excel(BytesIO(template_bytes))
+
+    output = BytesIO()
+    export_dashboard_workbook(output, workbook.expenses, opening_cash=0.0, scenarios=["Base", "Conservative"])
+
+    output.seek(0)
+    sheets = pd.ExcelFile(output).sheet_names
+    assert "Expenses" in sheets
+    assert "Company Summary" in sheets
+    assert "Consolidated" in sheets
+    assert "Cash Flow" in sheets


### PR DESCRIPTION
### Motivation
- Automate budget forecasting and reporting from an existing `Expenses` spreadsheet so individual company forecasts can be edited, consolidated, and exported as scenario dashboards. 
- Provide a reusable computation layer that normalizes raw expense data, produces company/consolidated summaries, projects cash flow, and emits scenario reports for downstream dashboards and Excel export.

### Description
- Add a Streamlit UI `acpl_app.py` that uploads an Excel workbook, exposes an editable company forecast grid, builds summaries and cash-flow projections, and exports a refreshed workbook. 
- Implement `src/budget_engine.py` with `BudgetWorkbook`, `_normalize_expenses`, `company_summary`, `consolidated_summary`, `cash_flow`, `scenario_reports`, `export_dashboard_workbook`, and `default_template` to centralize logic and Excel I/O. 
- Add tests `tests/test_budget_engine.py` that validate loading the template, building summaries, and that the exported workbook contains expected sheets. 
- Add `README.md` with usage instructions and `requirements.txt` listing `streamlit`, `pandas`, `openpyxl`, `xlsxwriter`, and `pytest`.

### Testing
- Ran `python -m py_compile acpl_app.py src/budget_engine.py tests/test_budget_engine.py`, which succeeded. 
- Ran `pytest -q`, which failed during collection with `ModuleNotFoundError: No module named 'pandas'` because required packages were not available in the environment. 
- Attempted `pip install -r requirements.txt`, which failed due to network/proxy restrictions preventing package downloads, preventing a full `pytest` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db0d7196a0832f997d8ea73503fd14)